### PR TITLE
Fix compiler warning in wrbb.h

### DIFF
--- a/firmware_develop/wrbb.h
+++ b/firmware_develop/wrbb.h
@@ -118,7 +118,7 @@
 #define LICENSE_MRUBY		"mruby is released under the MIT License."
 #define LICENSE_MRUBYURL	"https://github.com/mruby/mruby/blob/master/MITL"
 
-#ifndef BOARD == BOARD_P06
+#if BOARD != BOARD_P06
 	#define LICENSE_WRBB		"Wakayama-mruby-board is released under the MIT License."
 	#define LICENSE_WRBBURL		"https://github.com/wakayamarb/wrbb-v2lib-firm/blob/master/MITL"
 #else
@@ -311,4 +311,3 @@
 
 
 #endif // _WRBB_H_
-


### PR DESCRIPTION
コンパイル時に以下の警告が出力されていたため修正しました。

> wrbb_mruby/../wrbb.h:121:15: 警告: 余分なトークンが #ifndef 指示の後にあります [デフォルトで有効]
>  #ifndef BOARD == BOARD_P06