### PR TITLE
Add mrbgem - adafruit NeoPixel

### DIFF
--- a/firmware_develop/mruby/build_config.rb
+++ b/firmware_develop/mruby/build_config.rb
@@ -108,4 +108,14 @@ MRuby::CrossBuild.new("RX630") do |conf|
   #light-weight regular expression
   #conf.gem :github => "masamitsu-murase/mruby-hs-regexp", :branch => "master"
 
+  # # additional configrations for Arduino API
+  # GR_COMMON_PATH = "/xxxx/wrbb-v2lib-firm/firmware_develop/gr_common"
+  # conf.cc.flags << " -DGRSAKURA -DARDUINO=100 "
+  # conf.cc.include_paths << ["#{GR_COMMON_PATH}/lib/", "#{GR_COMMON_PATH}", "#{GR_COMMON_PATH}/core", "#{GR_COMMON_PATH}/lib/SPI", "#{GR_COMMON_PATH}/lib/Wire", "#{GR_COMMON_PATH}/lib/Servo" ]
+  # conf.cxx.flags = conf.cc.flags.dup
+  # conf.cxx.include_paths = conf.cc.include_paths.dup
+
+  # # NeoPixel library for mruby-arduino environment
+  # conf.gem :github => "takjn/mruby-arduino-neopixel", :branch => "master"
+
 end


### PR DESCRIPTION
GR-CITRUS向けのmrbgemのサンプルを作成してみました。コメントアウトしています。
- [mruby-arduino-neopixel](https://github.com/takjn/mruby-arduino-neopixel)

Arduino向けライブラリ(C++)をmrubyから呼び出せるようにしたものです。
- [Adafruit NeoPixel Library](https://github.com/adafruit/Adafruit_NeoPixel)

## 使い方
- 動作確認には、[adafruitの８ＬＥＤスティック](http://akizukidenshi.com/catalog/g/gM-08435/)が必要です。
- "additional configrations"と"NeoPixel library"のコメントアウトを外してください。(L.111 から L.119)
- "GR_COMMON_PATH"をお使いの環境(gr_commonがある場所)に合わせて設定してください。
- mrubyをビルドすると、libmruby.aに取り込まれます。

## サンプルコード
```mruby
neo_pixel=NeoPixel.new
neo_pixel.begin(10, 8) # adafruitのdin を GR-CITRUS:pin10に接続します

neo_pixel.set_brightness(5)

(0..7).each do |i|
    neo_pixel.set_pixel_color(i, 0, 0, 255) # LED番号、R、G、Bの順で指定します
    delay 500
    neo_pixel.show
end

neo_pixel.clear
```
