### PR TITLE
Add support of mruby program stop by serial break signal

### DIFF
--- a/firmware_release/gr_common/core/HardwareSerial.cpp
+++ b/firmware_release/gr_common/core/HardwareSerial.cpp
@@ -769,6 +769,16 @@ void WriteBulkINPacket(void)
 
 } // extern C
 
+bool HardwareSerial::isBreakState(void)
+{
+  return USBCDC_IsBreakState();
+}
+
+bool HardwareSerial::clearBreakState(void)
+{
+  return USBCDC_Clear_BreakState();
+}
+
 HardwareSerial Serial(0, NULL, MstpIdINVALID, INVALID_IO, INVALID_IO);
 #endif/*HAVE_HWSERIAL0*/
 

--- a/firmware_release/gr_common/core/HardwareSerial.h
+++ b/firmware_release/gr_common/core/HardwareSerial.h
@@ -160,6 +160,12 @@ class HardwareSerial : public Stream
     bool _buffer_available();
 #endif/*__RX600__*/
     void _tx_udr_empty_irq(void);
+
+#ifdef __RX600__
+    // Special terminal signals
+    bool isBreakState(void);
+    bool clearBreakState(void);
+#endif/*__RX600__*/
 };
 
 #ifndef __RX600__

--- a/firmware_release/gr_common/core/usb_cdc.c
+++ b/firmware_release/gr_common/core/usb_cdc.c
@@ -56,6 +56,7 @@
 #define SET_LINE_CODING                     0x20
 #define GET_LINE_CODING                     0x21
 #define SET_CONTROL_LINE_STATE              0x22
+#define SEND_BREAK                          0x23
 
 /*Size of GET_LINE_CODING response data*/
 #define LINE_CODING_DATA_SIZE               7
@@ -112,6 +113,9 @@ static SET_CONTROL_LINE_STATE_DATA g_SetControlLineData;
 
 /*Connected flag*/
 static volatile bool g_bConnected = false;
+
+/*Break flag*/
+static bool g_bBreakState = false;
 
 /*Bulk Out specific*/
 static BULK_OUT g_BulkOut = {
@@ -477,6 +481,36 @@ USB_ERR USBCDC_Cancel(void)
 ***********************************************************************************/
 
 /**********************************************************************
+* Outline       : USBCDC_IsBreakState
+* Description   : Read break (SEND_BREAK) state
+* Argument      : none
+* Return value  : current break state (true if CDC has received SEND_BREAK request)
+**********************************************************************/
+bool USBCDC_IsBreakState(void)
+{
+    return g_bBreakState;
+}
+/***********************************************************************************
+* End of function USBCDC_IsBreakState
+***********************************************************************************/
+
+/**********************************************************************
+* Outline       : USBCDC_Clear_BreakState
+* Description   : Clear break (SEND_BREAK) state
+* Argument      : none
+* Return value  : previous break state
+**********************************************************************/
+bool USBCDC_Clear_BreakState(void)
+{
+    bool bPreviousResult = g_bBreakState;
+    g_bBreakState = false;
+    return bPreviousResult;
+}
+/***********************************************************************************
+* End of function USBCDC_Clear_BreakState
+***********************************************************************************/
+
+/**********************************************************************
 * Outline       : CBCable
 * Description   : Callback when the USB cable is connected or disconnected.
 * Argument      : _bConnected: true = Connected, false = Disconnected.
@@ -709,6 +743,14 @@ static USB_ERR ProcessClassSetupPacket(SetupPacket* _pSetupPacket,
         {
             DEBUG_MSG_LOW(("USBCDC: SET_CONTROL_LINE_STATE\r\n"));
             /*No action required for this request.*/
+            /*No data response */
+            *_pNumBytes = 0;
+            break;
+        }
+        case SEND_BREAK:
+        {
+            DEBUG_MSG_LOW(("USBCDC: SEND_BREAK\r\n"));
+            g_bBreakState = true;
             /*No data response */
             *_pNumBytes = 0;
             break;

--- a/firmware_release/gr_common/core/usb_cdc.h
+++ b/firmware_release/gr_common/core/usb_cdc.h
@@ -58,6 +58,8 @@ USB_ERR USBCDC_Write_Async(uint32_t _NumBytes, const uint8_t* _Buffer, CB_DONE _
 USB_ERR USBCDC_Read(uint32_t _BufferSize, uint8_t* _Buffer, uint32_t* _pNumBytesRead);
 USB_ERR USBCDC_Read_Async(uint32_t _BufferSize, uint8_t* _Buffer, CB_DONE_OUT _cb);
 USB_ERR USBCDC_Cancel(void);
+bool USBCDC_IsBreakState(void);
+bool USBCDC_Clear_BreakState(void);
 
 #ifdef __cplusplus
 }

--- a/firmware_release/makefile
+++ b/firmware_release/makefile
@@ -36,7 +36,7 @@ GNU_PATH := c:/Renesas/GNURXv14.03-ELF/rx-elf/rx-elf/
 GCC_VERSION := 4.8-GNURX_v14.03
 CCINC := $(filter-out -I./wrbb_mruby/include/mruby, $(CCINC)) #string.hの重複を避けるため
 CFLAGS := -Wall -ffunction-sections -fno-function-cse -fsigned-char -fdata-sections -I. -I"$(GNU_PATH)rx-elf\include" -I"$(GNU_PATH)lib\gcc\rx-elf\$(GCC_VERSION)\include" -mno-balign -DGRCITRUS -DARDUINO=100 -DCPPAPP -D__RX_LITTLE_ENDIAN__=1 -O2 -g2 -g -flto -mlittle-endian-data -mcpu=rx600 -m64bit-doubles \
-          -DMRB_USE_FLOAT -DMRB_FUNCALL_ARGC_MAX=6 -DMRB_HEAP_PAGE_SIZE=24 -DMRB_USE_IV_SEGLIST -DMRB_IVHASH_INIT_SIZE=3 -DKHASH_DEFAULT_SIZE=2 -DPOOL_PAGE_SIZE=256 # mruby/build_config.rbを参照のこと
+          -DMRB_USE_FLOAT -DMRB_FUNCALL_ARGC_MAX=6 -DMRB_HEAP_PAGE_SIZE=24 -DMRB_USE_IV_SEGLIST -DMRB_IVHASH_INIT_SIZE=3 -DKHASH_DEFAULT_SIZE=2 -DPOOL_PAGE_SIZE=256 -DMRB_BYTECODE_DECODE_OPTION # mruby/build_config.rbを参照のこと
 AFLAGS := -Wall -ffunction-sections -fno-function-cse -fsigned-char -fdata-sections -I. -I"$(GNU_PATH)rx-elf\include" -I"$(GNU_PATH)lib\gcc\rx-elf\$(GCC_VERSION)\include" -mno-balign -DGRCITRUS -DARDUINO=100 -DCPPAPP -D__RX_LITTLE_ENDIAN__=1 -O2 -g2 -g -flto -mlittle-endian-data -mcpu=rx600 -m64bit-doubles
 SFLAGS :=--gdwarf2
 CC  = rx-elf-gcc

--- a/firmware_release/mruby/build_config.rb
+++ b/firmware_release/mruby/build_config.rb
@@ -178,7 +178,7 @@ MRuby::CrossBuild.new("RX630") do |conf|
     cc.defines << %w(MRB_IVHASH_INIT_SIZE=3)  # initial size for IV khash; ignored when MRB_USE_IV_SEGLIST is set
     cc.defines << %w(KHASH_DEFAULT_SIZE=2)    # default size of khash table bucket
     cc.defines << %w(POOL_PAGE_SIZE=256)      # effective only for use with mruby-eval
-    cc.defines << %w(MRB_ENABLE_DEBUG_HOOK)   # hooks for debugger
+    cc.defines << %w(MRB_BYTECODE_DECODE_OPTION)  # hooks for bytecode decoder
   end
 
   conf.cxx do |cxx|


### PR DESCRIPTION
mruby VMの強制終了機能を追加します。

### VMの強制終了実装
mruby 1.3.0から搭載された MRB_BYTECODE_DECODE_OPTION を用いてバイトコード実行をフックします。
終了指示を受けた後は全てのバイトコードを OP_STOP (VM停止命令) として解釈するようにして速やかにVMを終了させます(sExec.cpp)。
あくまでバイトコード単位であるため、当然ながらC実装部分を実行中の中断はできません。
ただし、delayメソッドにより長い時間を待っている最中だけは、即座に中断できるよう変更を加えました(sKernel.cpp)。

### 終了指示の与え方
シリアル通信のBREAK信号流用を提案します。TeraTermでいえば「コントロール→ブレークの送信」です。
これをCITRUS側で受信できるようにするため、USBCDCにブレーク受信の機能を追加しています(usb_cdc.{c,h})。
また、wrbb_mruby側からはHardwareSerialクラスを通してUSBCDCへアクセスするので、追加した機能にアクセスする
APIをHardwareSerial側にも追加しています(HardwareSerial.{cpp,h})
