### PR TITLE
Add constants - INPUT_PULLUP and OUTPUT_OPENDRAIN

### DIFF
--- a/firmware_release/wrbb_mruby/sGlobal.cpp
+++ b/firmware_release/wrbb_mruby/sGlobal.cpp
@@ -22,5 +22,6 @@ void global_Init(mrb_state *mrb)
 	mrb_define_global_const(mrb, "LOW", mrb_fixnum_value(0));
 	mrb_define_global_const(mrb, "INPUT", mrb_fixnum_value(0));
 	mrb_define_global_const(mrb, "OUTPUT", mrb_fixnum_value(1));
-	//mrb_define_global_const(mrb, "INPUT_PULLUP", mrb_fixnum_value(2));
+	mrb_define_global_const(mrb, "INPUT_PULLUP", mrb_fixnum_value(2));
+	mrb_define_global_const(mrb, "OUTPUT_OPENDRAIN", mrb_fixnum_value(3));
 }


### PR DESCRIPTION
pinModeメソッドのmode引数に指定できる `INPUT_PULLUP` と `OUTPUT_OPENDRAIN` を定数として追加します。