### PR TITLE
Add program abort by DTR off

### DIFF
--- a/firmware_release/gr_common/core/HardwareSerial.cpp
+++ b/firmware_release/gr_common/core/HardwareSerial.cpp
@@ -779,6 +779,16 @@ bool HardwareSerial::clearBreakState(void)
   return USBCDC_Clear_BreakState();
 }
 
+bool HardwareSerial::didDtrOffEvent(void)
+{
+  return USBCDC_DidDtrOffEvent();
+}
+
+bool HardwareSerial::clearDtrOffEvent(void)
+{
+  return USBCDC_Clear_DtrOffEvent();
+}
+
 HardwareSerial Serial(0, NULL, MstpIdINVALID, INVALID_IO, INVALID_IO);
 #endif/*HAVE_HWSERIAL0*/
 

--- a/firmware_release/gr_common/core/HardwareSerial.h
+++ b/firmware_release/gr_common/core/HardwareSerial.h
@@ -165,6 +165,8 @@ class HardwareSerial : public Stream
     // Special terminal signals
     bool isBreakState(void);
     bool clearBreakState(void);
+    bool didDtrOffEvent(void);
+    bool clearDtrOffEvent(void);
 #endif/*__RX600__*/
 };
 

--- a/firmware_release/gr_common/core/usb_cdc.h
+++ b/firmware_release/gr_common/core/usb_cdc.h
@@ -60,6 +60,8 @@ USB_ERR USBCDC_Read_Async(uint32_t _BufferSize, uint8_t* _Buffer, CB_DONE_OUT _c
 USB_ERR USBCDC_Cancel(void);
 bool USBCDC_IsBreakState(void);
 bool USBCDC_Clear_BreakState(void);
+bool USBCDC_DidDtrOffEvent(void);
+bool USBCDC_Clear_DtrOffEvent(void);
 
 #ifdef __cplusplus
 }

--- a/firmware_release/wrbb_eepfile/eeploader.cpp
+++ b/firmware_release/wrbb_eepfile/eeploader.cpp
@@ -108,6 +108,7 @@ int waitRcv(int msec){
 	int sa = 0;
 
 	USB_Serial->clearBreakState();		//ブレーク信号のクリア
+	USB_Serial->clearDtrOffEvent();
 	USB_Serial->print("Waiting ");
 	while(tm > millis()){
 		if (USB_Serial->available() > 0){
@@ -118,7 +119,7 @@ int waitRcv(int msec){
 			USB_Serial->print(" ");
 			USB_Serial->print(sa, 10);
 		}
-		if (USB_Serial->isBreakState()){
+		if (USB_Serial->isBreakState() || USB_Serial->didDtrOffEvent()){
 			USB_Serial->println("..Break!");
 			return 0;
 		}
@@ -235,6 +236,7 @@ bool writefile(const char *fname, int size, char code, char *readData)
 	}
 
 	USB_Serial->clearBreakState();		//ブレーク信号のクリア
+	USB_Serial->clearDtrOffEvent();
 	result = true;
 	for(int i=0; i<binsize; i++){
 		//b2aFlgが 0 のときはバイナリ、1 のときはバイナリが2バイトテキストで送られてくる
@@ -256,7 +258,7 @@ bool writefile(const char *fname, int size, char code, char *readData)
 			USB_Serial->print(".");
 		}
 
-		if (USB_Serial->isBreakState()){
+		if (USB_Serial->isBreakState() || USB_Serial->didDtrOffEvent()){
 			USB_Serial->println("..Break!");
 			result = false;
 			break;
@@ -322,6 +324,7 @@ void readfile(const char *fname, char code)
 	}
 
 	USB_Serial->clearBreakState();		//ブレーク信号のクリア
+	USB_Serial->clearDtrOffEvent();
 	for (int i = 0; i<binsize; i++){
 
 		if(code == 'G'){
@@ -335,7 +338,7 @@ void readfile(const char *fname, char code)
 			USB_Serial->print(bin, 16);
 		}
 
-		if (USB_Serial->isBreakState()){
+		if (USB_Serial->isBreakState() || USB_Serial->didDtrOffEvent()) {
 			break;
 		}
 	}

--- a/firmware_release/wrbb_mruby/sExec.cpp
+++ b/firmware_release/wrbb_mruby/sExec.cpp
@@ -67,7 +67,7 @@ uint8_t *RubyCode = NULL;					//動的にRubyコード領域を確保するた�
 //**************************************************
 static mrb_code forceVMStopHook(struct mrb_state* mrb, mrb_code code)
 {
-	if (Serial.isBreakState()) {
+	if (Serial.isBreakState() || Serial.didDtrOffEvent()) {
 		return OP_STOP;
 	}
 	return code;
@@ -94,6 +94,7 @@ bool RubyRun(void)
 	mrb->bytecode_decoder = forceVMStopHook;
 #endif
 	Serial.clearBreakState();
+	Serial.clearDtrOffEvent();
 
 	global_Init(mrb);	//グローバル変数の設定
 	kernel_Init(mrb);	//カーネル関連メソッドの設定
@@ -261,7 +262,7 @@ bool RubyRun(void)
 
 	SdClassFlag = false;
 
-	if (Serial.isBreakState()) {
+	if (Serial.isBreakState() || Serial.didDtrOffEvent()) {
 		notFinishFlag = true;
 	}
 

--- a/firmware_release/wrbb_mruby/sKernel.cpp
+++ b/firmware_release/wrbb_mruby/sKernel.cpp
@@ -89,7 +89,7 @@ int value;
 			delay( value );
 			value = 0;
 		}
-		if (USB_Serial->isBreakState()){
+		if (USB_Serial->isBreakState() || USB_Serial->didDtrOffEvent()){
 			// 長いdelayの途中に強制終了指示があった場合、delayを中断する
 			mrb_raise(mrb, E_RUNTIME_ERROR, "delay aborted");
 		}


### PR DESCRIPTION
Closes #22 

DTR=offとするUSB-CDCのリクエストを検知するようにし、RubyVM実行中(含むdelay中)・ファイル書き込み中にこれを検知するとVMや書き込みを強制終了します。
