### PR TITLE
Optimize writing to flash memory

### DIFF
--- a/firmware_release/gr_common/lib/EEPROM/EEPROM.cpp
+++ b/firmware_release/gr_common/lib/EEPROM/EEPROM.cpp
@@ -209,7 +209,7 @@ uint8_t EEPROMClass::write_block(int address, void *data, int len)
 		if (need_erase) {
 			result = flash_datarom_EraseBlock(DF_ADDRESS + address + block_ofs);
 		}
-	    result = flash_datarom_WriteData(
+		result = flash_datarom_WriteData(
 				DF_ADDRESS + address + block_ofs,
 				(uint8_t *)data + block_ofs,
 				DF_ERASE_BLOCK_SIZE);

--- a/firmware_release/gr_common/lib/EEPROM/EEPROM.cpp
+++ b/firmware_release/gr_common/lib/EEPROM/EEPROM.cpp
@@ -130,6 +130,7 @@ bool EEPROMClass::diff_flash(int address, void *data, int len)
 	return false;
 }
 
+// Write partial data (smaller than a block) to the specified address.
 uint8_t EEPROMClass::write_partial(int address, void *data, int len)
 {
 	uint8_t result = FLASH_SUCCESS;
@@ -150,6 +151,7 @@ uint8_t EEPROMClass::write_partial(int address, void *data, int len)
 		}
 	}
 
+	// Check if we need to erase the block.
 	for (int i = aligned_addr; i < aligned_end_addr; i += DF_ALIGN) {
 		if (diff_flash(i, buf + i - block_addr, DF_ALIGN)) {
 			if (flash_datarom_blankcheck(DF_ADDRESS + i)) {
@@ -177,6 +179,8 @@ uint8_t EEPROMClass::write_partial(int address, void *data, int len)
 	return result;
 }
 
+// Write data to the specified block.
+// The address and the length must be block-aligned.
 uint8_t EEPROMClass::write_block(int address, void *data, int len)
 {
 	uint8_t result = FLASH_SUCCESS;
@@ -213,6 +217,8 @@ uint8_t EEPROMClass::write_block(int address, void *data, int len)
 	return result;
 }
 
+// Write data to flash rom.
+// This accepts non-block-aligned address and length.
 uint8_t EEPROMClass::write(int address, void *data, int len)
 {
 	uint8_t result = FLASH_SUCCESS;

--- a/firmware_release/gr_common/lib/EEPROM/EEPROM.cpp
+++ b/firmware_release/gr_common/lib/EEPROM/EEPROM.cpp
@@ -63,6 +63,7 @@ uint8_t result = FLASH_SUCCESS;
 #ifndef __RX600__
 	eeprom_write_byte((unsigned char *) address, value);
 #else
+#if 0
 	uint8_t wbuf[DF_ALIGN];
 	uint8_t rbuf[DF_ERASE_BLOCK_SIZE]; // for block write
 	uint8_t bbuf[DF_ERASE_BLOCK_SIZE]; // for blank check
@@ -110,8 +111,136 @@ uint8_t result = FLASH_SUCCESS;
 	    result = flash_datarom_WriteData(DF_ADDRESS + w_addr, wbuf, DF_ALIGN);
 	}
 
+#else
+	result = write(address, &value, 1);
+#endif
 #endif //__RX600__
 	return result;
 }
+
+#ifdef __RX600__
+// Return true if there are any differences between the specified data and the flash rom.
+bool EEPROMClass::diff_flash(int address, void *data, int len)
+{
+	for (int i = 0; i < len; i++) {
+		if (read(address + i) != ((uint8_t *) data)[i]) {
+			return true;
+		}
+	}
+	return false;
+}
+
+uint8_t EEPROMClass::write_partial(int address, void *data, int len)
+{
+	uint8_t result = FLASH_SUCCESS;
+	int block_addr = address & DF_BLOCK_MASK;
+	int aligned_addr = address & ~(DF_ALIGN - 1);
+	int aligned_end_addr = (address + len + 1) & ~(DF_ALIGN - 1);
+	uint8_t buf[DF_ERASE_BLOCK_SIZE]; // for block write
+
+	bool need_erase = false;
+
+	// Copy data to internal buffer.
+	// Read flash if start or end address is not aligned.
+	for (int i = aligned_addr; i < aligned_end_addr; i++) {
+		if ((i < address) || (address + len <= i)) {
+			buf[i - block_addr] = read(i);
+		} else {
+			buf[i - block_addr] = ((uint8_t *)data)[i - address];
+		}
+	}
+
+	for (int i = aligned_addr; i < aligned_end_addr; i += DF_ALIGN) {
+		if (diff_flash(i, buf + i - block_addr, DF_ALIGN)) {
+			if (flash_datarom_blankcheck(DF_ADDRESS + i)) {
+				// not blank
+				need_erase = true;
+			}
+		}
+	}
+	if (need_erase) {
+		for (int i = block_addr; i < aligned_addr; i++) {
+			buf[i - block_addr] = read(i);
+		}
+		for (int i = aligned_end_addr; i < block_addr + DF_ERASE_BLOCK_SIZE; i++) {
+			buf[i - block_addr] = read(i);
+		}
+		result = flash_datarom_EraseBlock(DF_ADDRESS + block_addr);
+	    result = flash_datarom_WriteData(
+				DF_ADDRESS + block_addr, buf, DF_ERASE_BLOCK_SIZE);
+	} else {
+	    result = flash_datarom_WriteData(
+				DF_ADDRESS + aligned_addr,
+				buf + aligned_addr - block_addr,
+				aligned_end_addr - aligned_addr);
+	}
+	return result;
+}
+
+uint8_t EEPROMClass::write_block(int address, void *data, int len)
+{
+	uint8_t result = FLASH_SUCCESS;
+
+	if ((address & (DF_ERASE_BLOCK_SIZE - 1)) != 0) {
+		// The address is not block-aligned.
+		return FLASH_FAILURE;
+	}
+	if ((len & (DF_ERASE_BLOCK_SIZE - 1)) != 0) {
+		// The length is not block-aligned.
+		return FLASH_FAILURE;
+	}
+
+	for (int j = 0; j < len / DF_ERASE_BLOCK_SIZE; j++) {
+		bool need_erase = false;
+		int block_ofs = j * DF_ERASE_BLOCK_SIZE;
+		for (int i = 0; i < DF_ERASE_BLOCK_SIZE; i += DF_ALIGN) {
+			if (diff_flash(address + block_ofs + i,
+						(uint8_t *)data + block_ofs + i, DF_ALIGN)) {
+				if (flash_datarom_blankcheck(DF_ADDRESS + address + block_ofs + i)) {
+					// not blank
+					need_erase = true;
+				}
+			}
+		}
+		if (need_erase) {
+			result = flash_datarom_EraseBlock(DF_ADDRESS + address + block_ofs);
+		}
+	    result = flash_datarom_WriteData(
+				DF_ADDRESS + address + block_ofs,
+				(uint8_t *)data + block_ofs,
+				DF_ERASE_BLOCK_SIZE);
+	}
+	return result;
+}
+
+uint8_t EEPROMClass::write(int address, void *data, int len)
+{
+	uint8_t result = FLASH_SUCCESS;
+	int block_addr = address & DF_BLOCK_MASK;
+	int len2;
+
+	// Write first part before 32-byte aligned block.
+	if (block_addr != address) {
+		int off = address - block_addr;
+		len2 = (len > DF_ERASE_BLOCK_SIZE - off) ? DF_ERASE_BLOCK_SIZE - off : len;
+		result = write_partial(address, data, len2);
+		len -= len2;
+		address += len2;
+		data = (void *)((uint8_t *)data + len2);
+	}
+
+	// Write 32-byte aligned blocks.
+	len2 = len & DF_BLOCK_MASK;
+	result = write_block(address, data, len2);
+	len -= len2;
+	address += len2;
+	data = (void *)((uint8_t *)data + len2);
+
+	// Write remaining part.
+	result = write_partial(address, data, len);
+
+	return result;
+}
+#endif //__RX600__
 
 EEPROMClass EEPROM;

--- a/firmware_release/gr_common/lib/EEPROM/EEPROM.h
+++ b/firmware_release/gr_common/lib/EEPROM/EEPROM.h
@@ -31,6 +31,13 @@ class EEPROMClass
 #endif
         uint8_t read(int);
         uint8_t write(int, uint8_t);
+#ifdef __RX600__
+        uint8_t write_partial(int, void *, int);
+        uint8_t write_block(int, void *, int);
+        uint8_t write(int, void *, int);
+  private:
+        bool diff_flash(int address, void *data, int len);
+#endif
 };
 
 extern EEPROMClass EEPROM;

--- a/firmware_release/wrbb_eepfile/eepfile.cpp
+++ b/firmware_release/wrbb_eepfile/eepfile.cpp
@@ -302,6 +302,7 @@ int EEPFILE::fdelete(const char *filename)
 //******************************************************
 int EEPFILE::fwrite(FILEEEP *file, char *arry, int *len)
 {
+#if 0
 	int mlen = 0;
 	for(int i=0; i<*len; i++){
 		if (fwrite(file, arry[i])==-1){
@@ -311,6 +312,28 @@ int EEPFILE::fwrite(FILEEEP *file, char *arry, int *len)
 		mlen++;
 	}
 	return 1;
+#else
+	int secadd = 0;
+
+	//書き込むセクタを求めます
+	int sect = getSect(file, &secadd);
+	if (sect == -1) {
+		return -1;
+	}
+
+	//書き込みます
+	int add = sect * EEPSECTOR_SIZE + secadd;
+	epWrite(add, (unsigned char *)arry, *len);
+
+	//seekをlen進めます
+	file->seek += *len;
+
+	//seek位置がfileSizeを超えた場合
+	if (file->seek > file->filesize) {
+		file->filesize = file->seek;
+	}
+	return 1;
+#endif
 }
 
 //******************************************************
@@ -319,6 +342,7 @@ int EEPFILE::fwrite(FILEEEP *file, char *arry, int *len)
 //******************************************************
 int EEPFILE::fwrite(FILEEEP *file, char dat)
 {
+#if 0
 	int secadd = 0;
 
 	//書き込むセクタを求めます
@@ -339,6 +363,10 @@ int EEPFILE::fwrite(FILEEEP *file, char dat)
 		file->filesize = file->seek;
 	}
 	return 1;
+#else
+	int len = 1;
+	return fwrite(file, &dat, &len);
+#endif
 }
 
 //******************************************************
@@ -389,8 +417,7 @@ void EEPFILE::fclose(FILEEEP *file)
 		//ファイルサイズを書き込みます
 		DEBUG_PRINT("fclose", "EEP_WRITE");
 		int add = file->stasector * EEPSECTOR_SIZE;
-		epWrite(add + file->offsetaddress - 1, (file->filesize>>8) & 0xFF);
-		epWrite(add + file->offsetaddress - 2, file->filesize & 0xFF);
+		epWrite(add + file->offsetaddress - 2, (unsigned char *)&file->filesize, 2);
 	}
 
 	int next;
@@ -582,16 +609,12 @@ void EEPFILE::setFile( FILEEEP *file, const char *filename, int sect, int mode)
 	Sect[sect] |= mode << 10;		//ファイル使用中フラグ
 
 	//ファイル名を書き込む
-	for( int i=0; i<len; i++){
-		epWrite( add + i, filename[i] );
-	}
-	epWrite( add + len, 0 );
+	epWrite( add, (unsigned char *)filename, len + 1 );
 
 	//ファイルサイズ 0 セット
-	epWrite( add + len + 1, 0 );
-	epWrite( add + len + 2, 0 );
-
 	file->filesize = 0;
+	epWrite( add + len + 1, (unsigned char *)&file->filesize, 2 );
+
 	file->stasector = sect;
 	file->offsetaddress = len + 3;
 	file->seek = 0;
@@ -607,8 +630,10 @@ void EEPFILE::saveFat(void)
 		// 11,12ビット目は0にして保存する 1111 0011 1111 1111
 		//a1 = (Sect[i] & (~(3 << 10))) & 0xFF;
 		//a2 = ((Sect[i] & (~(3 << 10)))>>8) & 0xFF;
-		epWrite( EEPFAT_START + i*2, (Sect[i] & (~(3 << 10))) & 0xFF);
-		epWrite( EEPFAT_START + i*2 + 1, ((Sect[i] & (~(3 << 10)))>>8) & 0xFF);
+		unsigned char buf[2];
+		buf[0] = (Sect[i] & (~(3 << 10))) & 0xFF;
+		buf[1] = ((Sect[i] & (~(3 << 10)))>>8) & 0xFF;
+		epWrite(EEPFAT_START + i*2, buf, 2);
 	}
 }
 
@@ -685,6 +710,11 @@ int EEPFILE::epWrite(unsigned long addr,unsigned char data)
 		return (EEPROM.write(addr, data) == FLASH_SUCCESS ? 1 : -1);
 	}
 	return 1;
+}
+
+int EEPFILE::epWrite(unsigned long addr, unsigned char *data, unsigned long len)
+{
+	return (EEPROM.write(addr, data, len) == FLASH_SUCCESS ? 1 : -1);
 }
 
 //*********

--- a/firmware_release/wrbb_eepfile/eepfile.h
+++ b/firmware_release/wrbb_eepfile/eepfile.h
@@ -58,6 +58,7 @@ class EEPFILE
 	void saveFat(void);
 	int getSect(FILEEEP *file, int *add);
 	int epWrite(unsigned long addr,unsigned char data);
+	int epWrite(unsigned long addr, unsigned char *data, unsigned long len);
 	int isReady();
 };
 


### PR DESCRIPTION
`W` コマンドなどでのフラッシュへのファイルの書き込みを大幅に高速化しました。

今までは1バイトずつ書き込みを行っていたことで2回に1回はブロックの消去が発生していましたが、32バイトのブロック単位で書き込むように変更しています。

10KB 程度のファイルの転送に1分以上掛かっていたところが、1.5秒程度で完了するようになり、50倍程度の高速化となりました。